### PR TITLE
Add ability to delete analysis history entries

### DIFF
--- a/server/routes.ts
+++ b/server/routes.ts
@@ -142,7 +142,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
         result,
         checklist.id,
         textToAnalyze,
-        managerId
+        managerId ?? undefined
       );
 
       // Return result with analysis ID
@@ -358,6 +358,22 @@ export async function registerRoutes(app: Express): Promise<Server> {
       console.error("Get analyses error:", error);
       res.status(500).json({
         error: error instanceof Error ? error.message : "Ошибка получения анализов",
+      });
+    }
+  });
+
+  // DELETE /api/analyses/:id - Удалить анализ
+  app.delete("/api/analyses/:id", async (req, res) => {
+    try {
+      const deleted = await storage.deleteAnalysis(req.params.id);
+      if (!deleted) {
+        return res.status(404).json({ error: "Анализ не найден" });
+      }
+      res.status(204).send();
+    } catch (error) {
+      console.error("Delete analysis error:", error);
+      res.status(500).json({
+        error: error instanceof Error ? error.message : "Ошибка удаления анализа",
       });
     }
   });

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -37,6 +37,7 @@ export interface IStorage {
     checklistReport: any;
     objectionsReport: any;
   }>>;
+  deleteAnalysis(id: string): Promise<boolean>;
 }
 
 export class DatabaseStorage implements IStorage {
@@ -303,6 +304,18 @@ export class DatabaseStorage implements IStorage {
       checklistReport: a.checklistReport,
       objectionsReport: a.objectionsReport,
     }));
+  }
+
+  async deleteAnalysis(id: string): Promise<boolean> {
+    const numId = parseInt(id, 10);
+    if (isNaN(numId)) return false;
+
+    const result = await db
+      .delete(analyses)
+      .where(eq(analyses.id, numId))
+      .returning();
+
+    return result.length > 0;
   }
 }
 


### PR DESCRIPTION
## Summary
- add a backend endpoint and storage helper to remove saved analyses
- add a delete action to the history page with user feedback and loading state

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68fe471ef2b88325bd08f9009450922b