### PR TITLE
chore: prepare backend for Railway

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -7,6 +7,10 @@ const app = express();
 app.use(express.json());
 app.use(express.urlencoded({ extended: false }));
 
+app.get("/healthz", (_req, res) => {
+  res.json({ status: "ok" });
+});
+
 app.use((req, res, next) => {
   const start = Date.now();
   const path = req.path;

--- a/server/package.json
+++ b/server/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "ai-manager-backend",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "build": "tsc -p .",
+    "start": "node --enable-source-maps dist/index.js"
+  },
+  "devDependencies": {
+    "@types/express": "^4.17.21",
+    "@types/node": "^20.16.11",
+    "tsx": "^4.20.5",
+    "typescript": "^5.6.3"
+  }
+}

--- a/server/tsconfig.json
+++ b/server/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "outDir": "dist",
+    "rootDir": ".",
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "skipLibCheck": true,
+    "sourceMap": true,
+    "resolveJsonModule": true,
+    "baseUrl": ".",
+    "paths": {
+      "@shared/*": ["../shared/*"]
+    }
+  },
+  "include": ["**/*.ts"],
+  "exclude": ["dist", "node_modules"]
+}


### PR DESCRIPTION
## Summary
- add a server package manifest with Railway-friendly build and start scripts plus required typings
- configure a dedicated TypeScript project for the server that emits compiled output to `dist`
- expose a `/healthz` endpoint while keeping the listener bound to the provided host and port

## Testing
- npx tsc -p server/tsconfig.json *(fails: pre-existing strict type errors in server code and shared imports)*

------
https://chatgpt.com/codex/tasks/task_e_68fe51ba73388325904e52913871672a