### PR TITLE
chore: guard client builds with dependency linting

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,0 +1,3 @@
+#!/usr/bin/env sh
+set -e
+npm --prefix client run lint

--- a/client/eslint.config.js
+++ b/client/eslint.config.js
@@ -1,0 +1,52 @@
+import tsParser from '@typescript-eslint/parser';
+import pluginImport from 'eslint-plugin-import';
+
+const sharedSettings = {
+  'import/parsers': {
+    '@typescript-eslint/parser': ['.ts', '.tsx'],
+  },
+  'import/resolver': {
+    node: {
+      extensions: ['.js', '.jsx', '.ts', '.tsx'],
+    },
+  },
+};
+
+export default [
+  {
+    ignores: ['dist', 'node_modules'],
+  },
+  {
+    files: ['src/**/*.{ts,tsx,js,jsx}'],
+    languageOptions: {
+      parser: tsParser,
+      parserOptions: {
+        ecmaVersion: 'latest',
+        sourceType: 'module',
+        ecmaFeatures: {
+          jsx: true,
+        },
+      },
+      globals: {
+        console: 'readonly',
+        document: 'readonly',
+        navigator: 'readonly',
+        window: 'readonly',
+      },
+    },
+    plugins: {
+      import: pluginImport,
+    },
+    settings: sharedSettings,
+    rules: {
+      'import/no-extraneous-dependencies': [
+        'error',
+        {
+          devDependencies: false,
+          optionalDependencies: false,
+          peerDependencies: false,
+        },
+      ],
+    },
+  },
+];

--- a/client/package.json
+++ b/client/package.json
@@ -5,7 +5,8 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "build": "vite build",
+    "lint": "eslint \"src/**/*.{ts,tsx,js,jsx}\"",
+    "build": "npm run lint && vite build",
     "preview": "vite preview"
   },
   "dependencies": {
@@ -21,7 +22,10 @@
     "@tailwindcss/typography": "^0.5.15",
     "@types/react": "^18.3.3",
     "@types/react-dom": "^18.3.3",
+    "@typescript-eslint/parser": "^8.11.0",
     "@vitejs/plugin-react": "^4.2.0",
+    "eslint": "^9.13.0",
+    "eslint-plugin-import": "^2.29.1",
     "typescript": "^5.6.0",
     "vite": "^5.0.0"
   }

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "preview": "vite preview",
     "start": "NODE_ENV=production node dist/index.js",
     "check": "tsc",
-    "db:push": "drizzle-kit push"
+    "db:push": "drizzle-kit push",
+    "prepare": "husky install"
   },
   "dependencies": {
     "@google/genai": "^1.25.0",
@@ -113,7 +114,8 @@
     "tailwindcss": "^3.4.17",
     "tsx": "^4.20.5",
     "typescript": "5.6.3",
-    "vite": "^5.4.20"
+    "vite": "^5.4.20",
+    "husky": "^9.1.6"
   },
   "optionalDependencies": {
     "bufferutil": "^4.0.8"


### PR DESCRIPTION
## Summary
- add an ESLint flat config for the client that enforces `import/no-extraneous-dependencies`
- run the new lint script before the Vite build and include the required linting dev dependencies
- set up a Husky pre-push hook via the root package to lint the client automatically

## Testing
- npm --prefix client run lint *(fails until the new dev dependencies are installed in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ff1837eb888325b8d8f4c0a671a8f0