### PR TITLE
Pin server dependency versions

### DIFF
--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -11,17 +11,17 @@
       "dependencies": {
         "cors": "file:vendor/cors",
         "dotenv": "file:vendor/dotenv",
-        "express": "^4.21.2",
-        "@neondatabase/serverless": "^0.10.4",
-        "drizzle-orm": "^0.39.1",
-        "nanoid": "^3.3.7",
-        "ws": "^8.18.0"
+        "express": "4.21.2",
+        "@neondatabase/serverless": "0.10.4",
+        "drizzle-orm": "0.39.1",
+        "nanoid": "3.3.7",
+        "ws": "8.18.0"
       },
       "devDependencies": {
-        "@types/express": "^4.17.21",
-        "@types/node": "^20.16.11",
-        "tsx": "^4.20.5",
-        "typescript": "^5.6.3"
+        "@types/express": "4.17.21",
+        "@types/node": "20.16.11",
+        "tsx": "4.20.5",
+        "typescript": "5.6.3"
       }
     },
     "vendor/cors": {

--- a/server/package.json
+++ b/server/package.json
@@ -12,16 +12,16 @@
   "dependencies": {
     "cors": "file:vendor/cors",
     "dotenv": "file:vendor/dotenv",
-    "express": "^4.21.2",
-    "@neondatabase/serverless": "^0.10.4",
-    "drizzle-orm": "^0.39.1",
-    "nanoid": "^3.3.7",
-    "ws": "^8.18.0"
+    "express": "4.21.2",
+    "@neondatabase/serverless": "0.10.4",
+    "drizzle-orm": "0.39.1",
+    "nanoid": "3.3.7",
+    "ws": "8.18.0"
   },
   "devDependencies": {
-    "@types/express": "^4.17.21",
-    "@types/node": "^20.16.11",
-    "tsx": "^4.20.5",
-    "typescript": "^5.6.3"
+    "@types/express": "4.17.21",
+    "@types/node": "20.16.11",
+    "tsx": "4.20.5",
+    "typescript": "5.6.3"
   }
 }


### PR DESCRIPTION
## Summary
- pin the server service dependencies and dev dependencies to exact versions to keep the lockfile in sync

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68ff24c3b1488325bd40c19e31eb755b