### PR TITLE
chore(server): stabilize railway deployment

### DIFF
--- a/server/.npmrc
+++ b/server/.npmrc
@@ -1,0 +1,1 @@
+registry=https://registry.npmjs.org/

--- a/server/index.ts
+++ b/server/index.ts
@@ -121,6 +121,10 @@ app.get("/healthz", (_req, res) => {
   res.status(200).json({ status: "ok" });
 });
 
+app.get("/health", (_req, res) => {
+  res.status(200).json({ status: "ok" });
+});
+
 app.use((req, res, next) => {
   const start = Date.now();
   const path = req.path;

--- a/server/package.json
+++ b/server/package.json
@@ -6,8 +6,9 @@
   "scripts": {
     "dev": "tsx watch index.ts",
     "build": "tsc -p tsconfig.json",
-    "start": "node --enable-source-maps dist/index.js",
-    "start:dev": "tsx index.ts"
+    "start": "node dist/index.js",
+    "start:dev": "tsx index.ts",
+    "start:prod": "NODE_ENV=production node dist/index.js"
   },
   "dependencies": {
     "cors": "file:vendor/cors",
@@ -23,5 +24,8 @@
     "@types/node": "20.16.11",
     "tsx": "4.20.5",
     "typescript": "5.6.3"
+  },
+  "engines": {
+    "node": ">=18 <23"
   }
 }


### PR DESCRIPTION
## Summary
- add explicit production start script and node engine constraint for the backend service
- expose a /health endpoint alongside the existing /healthz check
- pin the npm registry for the backend package to avoid registry drift

## Testing
- npm_config_https_proxy=http://proxy:8080 npm_config_http_proxy=http://proxy:8080 npm --progress=false ci --omit=dev --loglevel=error *(fails: registry access blocked in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ff426960108325bbb437d12e361003