### PR TITLE
Optimize client bundle loading

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -1,14 +1,16 @@
+import { Suspense, lazy } from "react";
 import { Switch, Route } from "wouter";
 import { queryClient } from "./lib/queryClient";
 import { QueryClientProvider } from "@tanstack/react-query";
 import { Toaster } from "@/components/ui/toaster";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import { ThemeProvider } from "@/lib/theme-provider";
-import Home from "@/pages/home";
-import History from "@/pages/history";
-import AnalysisDetail from "@/pages/analysis-detail";
-import Managers from "@/pages/managers";
-import NotFound from "@/pages/not-found";
+
+const Home = lazy(() => import("@/pages/home"));
+const History = lazy(() => import("@/pages/history"));
+const AnalysisDetail = lazy(() => import("@/pages/analysis-detail"));
+const Managers = lazy(() => import("@/pages/managers"));
+const NotFound = lazy(() => import("@/pages/not-found"));
 
 function Router() {
   return (
@@ -28,7 +30,15 @@ function App() {
       <ThemeProvider defaultTheme="dark">
         <TooltipProvider>
           <Toaster />
-          <Router />
+          <Suspense
+            fallback={
+              <div className="flex min-h-screen items-center justify-center bg-background text-muted-foreground">
+                Загрузка интерфейса...
+              </div>
+            }
+          >
+            <Router />
+          </Suspense>
         </TooltipProvider>
       </ThemeProvider>
     </QueryClientProvider>

--- a/client/src/components/checklist-selector.tsx
+++ b/client/src/components/checklist-selector.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from "react";
+import { Suspense, lazy, useEffect, useState } from "react";
 import { Download, Upload, Copy, FileUp } from "lucide-react";
 import { useQuery, useMutation } from "@tanstack/react-query";
 import { apiRequest, queryClient } from "@/lib/queryClient";
@@ -21,8 +21,13 @@ import {
   DialogTitle,
   DialogTrigger,
 } from "@/components/ui/dialog";
-import { ChecklistUpload } from "@/components/checklist-upload";
 import { Checklist, InsertChecklist } from "@/lib/rest";
+
+const ChecklistUpload = lazy(() =>
+  import("@/components/checklist-upload").then((module) => ({
+    default: module.ChecklistUpload,
+  }))
+);
 
 interface ChecklistSelectorProps {
   onChecklistChange: (checklist: Checklist) => void;
@@ -208,7 +213,15 @@ export function ChecklistSelector({ onChecklistChange }: ChecklistSelectorProps)
                     AI автоматически поймёт структуру вашего чек-листа.
                   </DialogDescription>
                 </DialogHeader>
-                <ChecklistUpload onChecklistCreated={handleChecklistUploaded} />
+                <Suspense
+                  fallback={
+                    <div className="py-8 text-center text-sm text-muted-foreground">
+                      Загрузка формы загрузки...
+                    </div>
+                  }
+                >
+                  <ChecklistUpload onChecklistCreated={handleChecklistUploaded} />
+                </Suspense>
               </DialogContent>
             </Dialog>
 

--- a/client/src/pages/history.tsx
+++ b/client/src/pages/history.tsx
@@ -13,8 +13,8 @@ import {
   Loader2,
 } from "lucide-react";
 import { Link } from "wouter";
-import { formatDistanceToNow } from "date-fns";
-import { ru } from "date-fns/locale";
+import formatDistanceToNow from "date-fns/formatDistanceToNow";
+import ru from "date-fns/locale/ru";
 import { apiRequest, queryClient } from "@/lib/queryClient";
 import { useToast } from "@/hooks/use-toast";
 

--- a/client/src/pages/home.tsx
+++ b/client/src/pages/home.tsx
@@ -1,19 +1,49 @@
-import { useState } from "react";
+import { Suspense, lazy, useState } from "react";
 import { Phone, MessageCircle, Sparkles, History, Users } from "lucide-react";
 import { Link } from "wouter";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { Button } from "@/components/ui/button";
 import { Card } from "@/components/ui/card";
 import { useToast } from "@/hooks/use-toast";
-import { AudioUpload } from "@/components/audio-upload";
-import { TextInput } from "@/components/text-input";
-import { TranscriptEditor } from "@/components/transcript-editor";
-import { ChecklistSelector } from "@/components/checklist-selector";
-import { ManagerSelector } from "@/components/manager-selector";
-import { AnalysisResults } from "@/components/analysis-results";
 import { ThemeToggle } from "@/components/theme-toggle";
 import { Checklist, AnalysisReport } from "@/lib/rest";
 import { buildApiUrl } from "@/lib/apiBase";
+
+const AudioUpload = lazy(() =>
+  import("@/components/audio-upload").then((module) => ({
+    default: module.AudioUpload,
+  }))
+);
+
+const TextInput = lazy(() =>
+  import("@/components/text-input").then((module) => ({
+    default: module.TextInput,
+  }))
+);
+
+const TranscriptEditor = lazy(() =>
+  import("@/components/transcript-editor").then((module) => ({
+    default: module.TranscriptEditor,
+  }))
+);
+
+const ChecklistSelector = lazy(() =>
+  import("@/components/checklist-selector").then((module) => ({
+    default: module.ChecklistSelector,
+  }))
+);
+
+const ManagerSelector = lazy(() =>
+  import("@/components/manager-selector").then((module) => ({
+    default: module.ManagerSelector,
+  }))
+);
+
+const AnalysisResults = lazy(() =>
+  import("@/components/analysis-results").then((module) => ({
+    default: module.AnalysisResults,
+  }))
+);
 
 export default function Home() {
   const [activeTab, setActiveTab] = useState<"call" | "correspondence">("call");
@@ -142,20 +172,44 @@ export default function Home() {
               </TabsList>
 
               <TabsContent value="call" className="space-y-6 mt-6">
-                <AudioUpload
-                  onTranscript={setTranscript}
-                  isProcessing={isProcessingAudio}
-                  setIsProcessing={setIsProcessingAudio}
-                  onUploadStart={handleResetAnalysis}
-                />
-                
+                <Suspense
+                  fallback={
+                    <div className="flex min-h-64 items-center justify-center rounded-lg border border-dashed text-muted-foreground">
+                      Загрузка загрузчика аудио...
+                    </div>
+                  }
+                >
+                  <AudioUpload
+                    onTranscript={setTranscript}
+                    isProcessing={isProcessingAudio}
+                    setIsProcessing={setIsProcessingAudio}
+                    onUploadStart={handleResetAnalysis}
+                  />
+                </Suspense>
+
                 {transcript && (
-                  <TranscriptEditor value={transcript} onChange={setTranscript} />
+                  <Suspense
+                    fallback={
+                      <Card className="p-6 text-center text-muted-foreground">
+                        Загрузка редактора транскрипта...
+                      </Card>
+                    }
+                  >
+                    <TranscriptEditor value={transcript} onChange={setTranscript} />
+                  </Suspense>
                 )}
               </TabsContent>
 
               <TabsContent value="correspondence" className="space-y-6 mt-6">
-                <TextInput value={correspondenceText} onChange={setCorrespondenceText} />
+                <Suspense
+                  fallback={
+                    <Card className="p-6 text-center text-muted-foreground">
+                      Загрузка текстовой формы...
+                    </Card>
+                  }
+                >
+                  <TextInput value={correspondenceText} onChange={setCorrespondenceText} />
+                </Suspense>
               </TabsContent>
             </Tabs>
 
@@ -183,16 +237,42 @@ export default function Home() {
               </Card>
             )}
 
-            {analysisReport && <AnalysisResults report={analysisReport} />}
+            {analysisReport && (
+              <Suspense
+                fallback={
+                  <Card className="p-6 text-center text-muted-foreground">
+                    Загрузка результатов анализа...
+                  </Card>
+                }
+              >
+                <AnalysisResults report={analysisReport} />
+              </Suspense>
+            )}
           </div>
 
           {/* Sidebar */}
           <aside className="space-y-6">
-            <ManagerSelector
-              onManagerChange={setSelectedManagerId}
-              selectedManagerId={selectedManagerId}
-            />
-            <ChecklistSelector onChecklistChange={setActiveChecklist} />
+            <Suspense
+              fallback={
+                <Card className="p-6 text-center text-muted-foreground">
+                  Загрузка списка менеджеров...
+                </Card>
+              }
+            >
+              <ManagerSelector
+                onManagerChange={setSelectedManagerId}
+                selectedManagerId={selectedManagerId}
+              />
+            </Suspense>
+            <Suspense
+              fallback={
+                <Card className="p-6 text-center text-muted-foreground">
+                  Загрузка чек-листов...
+                </Card>
+              }
+            >
+              <ChecklistSelector onChecklistChange={setActiveChecklist} />
+            </Suspense>
           </aside>
         </div>
       </div>

--- a/client/vite.config.ts
+++ b/client/vite.config.ts
@@ -12,9 +12,37 @@ export default defineConfig({
     alias: {
       "@": resolve(rootDir, "src"),
       "@shared": resolve(rootDir, "../shared"),
-      "@assets": resolve(rootDir, "../attached_assets")
+      "@assets": resolve(rootDir, "../attached_assets"),
     }
   },
-  build: { outDir: "dist" },
+  build: {
+    outDir: "dist",
+    chunkSizeWarningLimit: 800,
+    rollupOptions: {
+      output: {
+        manualChunks(id) {
+          if (!id.includes("node_modules")) {
+            return;
+          }
+
+          if (id.includes("recharts")) {
+            return "charts";
+          }
+
+          if (id.includes("@radix-ui")) {
+            return "radix";
+          }
+
+          if (
+            /[\\/]node_modules[\\/](react|react-dom|scheduler|use-sync-external-store)/.test(
+              id
+            ) || id.includes("react/jsx-runtime")
+          ) {
+            return "react";
+          }
+        },
+      },
+    },
+  },
   server: { port: 5173 }
 });


### PR DESCRIPTION
## Summary
- lazy-load the client routes and heavy UI modules so dropzone- and chart-related code only loads on demand
- configure Vite to create dedicated manual chunks for React, Radix UI, and Recharts while raising the chunk size warning threshold
- switch history page date-fns usage to point imports and add Suspense fallbacks for lazy components

## Testing
- npm ci *(fails: 403 Forbidden fetching @types/react-dom)*
- npm install *(fails: 403 Forbidden fetching @types/react-dom)*
- npm run build *(fails: missing dependencies because packages could not be installed)*

------
https://chatgpt.com/codex/tasks/task_e_68ff4d4b46ec832588ab74d673e50123