### PR TITLE
Ensure Railway builds client workspace with Tailwind config

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -9,6 +9,12 @@
     "build": "vite build",
     "preview": "vite preview"
   },
+  "tailwind": {
+    "config": "./tailwind.config.ts"
+  },
+  "postcss": {
+    "path": "./postcss.config.js"
+  },
   "engines": {
     "node": ">=20 <21"
   },

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "build:server": "esbuild server/index.ts --platform=node --packages=external --bundle --format=esm --outdir=dist",
     "install:client": "npm ci --prefix client",
     "build:client": "npm run build --prefix client",
+    "start:client": "npm run preview --prefix client",
     "preview": "vite preview",
     "start": "NODE_ENV=production node dist/index.js",
     "check": "tsc",


### PR DESCRIPTION
## Summary
- add a start:client helper script so Railway can run preview/build commands inside the client workspace
- declare explicit Tailwind CSS and PostCSS configuration paths in the client package to avoid default resolution issues

## Testing
- `npm ci` *(fails: 403 Forbidden from registry.npmjs.org while downloading @types/react-dom)*

------
https://chatgpt.com/codex/tasks/task_e_69034958510c8325a3de2693d2a3096d