### PR TITLE
Fix Tailwind production build configuration

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -10,7 +10,7 @@
     "preview": "vite preview"
   },
   "tailwind": {
-    "config": "./tailwind.config.ts"
+    "config": "./tailwind.config.js"
   },
   "postcss": {
     "path": "./postcss.config.js"

--- a/client/postcss.config.js
+++ b/client/postcss.config.js
@@ -1,4 +1,4 @@
-export default {
+module.exports = {
   plugins: {
     tailwindcss: {},
     autoprefixer: {},

--- a/client/tailwind.config.js
+++ b/client/tailwind.config.js
@@ -1,9 +1,14 @@
-import type { Config } from "tailwindcss";
-import tailwindcssAnimate from "tailwindcss-animate";
+const tailwindcssAnimate = require("tailwindcss-animate");
 
-const config = {
+/** @type {import('tailwindcss').Config} */
+module.exports = {
   darkMode: ["class"],
-  content: ["./index.html", "./src/**/*.{ts,tsx,js,jsx}"],
+  content: [
+    "./index.html",
+    "./src/**/*.{ts,tsx,js,jsx}",
+    "../shared/**/*.{ts,tsx,js,jsx}",
+    "../server/**/*.{ts,tsx,js,jsx}",
+  ],
   theme: {
     container: {
       center: true,
@@ -95,7 +100,13 @@ const config = {
       },
     },
   },
+  safelist: [
+    "border-border",
+    "bg-background",
+    "text-foreground",
+    "ring-ring",
+    "data-[state=open]:animate-in",
+    "data-[state=closed]:animate-out",
+  ],
   plugins: [tailwindcssAnimate],
-} satisfies Config;
-
-export default config;
+};


### PR DESCRIPTION
## Summary
- convert the PostCSS configuration to CommonJS so Vercel can load it during production builds
- replace the Tailwind configuration with a JavaScript version that safelists shadcn/radix tokens and scans shared/server sources
- update the client package metadata to reference the new Tailwind config path

## Testing
- `npm ci` *(fails: 403 Forbidden from registry in sandbox)*

------
https://chatgpt.com/codex/tasks/task_e_69036065b1e88325ba969323d098e40d