### PR TITLE
Fix Vite base path for Vercel deployment

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -11,6 +11,6 @@
   </head>
   <body>
     <div id="root"></div>
-    <script type="module" src="/src/main.tsx"></script>
+    <script type="module" src="./src/main.tsx"></script>
   </body>
 </html>

--- a/client/vite.config.ts
+++ b/client/vite.config.ts
@@ -7,6 +7,7 @@ import { fileURLToPath } from "node:url";
 const rootDir = dirname(fileURLToPath(import.meta.url));
 
 export default defineConfig({
+  base: "./",
   plugins: [react(), tsconfigPaths()],
   resolve: {
     alias: {


### PR DESCRIPTION
## Summary
- set the Vite base path to a relative value so built assets resolve correctly on Vercel
- load the entry script in index.html via a relative path to avoid absolute URL rewrites stripping styles

## Testing
- not run (dependencies unavailable in environment)

------
https://chatgpt.com/codex/tasks/task_e_6905042bf9588325a025b4aea0a19069