### PR TITLE
Fix Vercel styling by using absolute asset base

### DIFF
--- a/client/vite.config.ts
+++ b/client/vite.config.ts
@@ -7,7 +7,13 @@ import { fileURLToPath } from "node:url";
 const rootDir = dirname(fileURLToPath(import.meta.url));
 
 export default defineConfig({
-  base: "./",
+  // Vercel serves the client from the root domain. Using a relative base path
+  // like "./" breaks asset URLs (CSS/JS) on deep links because the browser
+  // resolves them against the current route (e.g. "/dashboard/assets/...").
+  // This caused the Tailwind bundle to 404 in production and the UI appeared
+  // unstyled. Switching back to the default absolute base keeps asset URLs
+  // rooted at "/" so they load correctly no matter which route is opened.
+  base: "/",
   plugins: [react(), tsconfigPaths()],
   resolve: {
     alias: {


### PR DESCRIPTION
## Summary
- ensure the Vite build emits asset URLs rooted at "/" so deep links on Vercel load CSS/JS correctly
- document the reasoning in the config to avoid regressions

## Testing
- not run (dependency installation requires network access that is unavailable in this environment)

------
https://chatgpt.com/codex/tasks/task_e_6905a86809688325ab41d559342a5c2b