### PR TITLE
Fix dropdown stacking for selectors

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -5,6 +5,7 @@ import { QueryClientProvider } from "@tanstack/react-query";
 import { Toaster } from "@/components/ui/toaster";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import { ThemeProvider } from "@/lib/theme-provider";
+import { DropdownProvider } from "@/contexts/dropdown-provider";
 
 const Home = lazy(() => import("@/pages/home"));
 const History = lazy(() => import("@/pages/history"));
@@ -29,16 +30,18 @@ function App() {
     <QueryClientProvider client={queryClient}>
       <ThemeProvider defaultTheme="dark">
         <TooltipProvider>
-          <Toaster />
-          <Suspense
-            fallback={
-              <div className="flex min-h-screen items-center justify-center bg-background text-muted-foreground">
-                Загрузка интерфейса...
-              </div>
-            }
-          >
-            <Router />
-          </Suspense>
+          <DropdownProvider>
+            <Toaster />
+            <Suspense
+              fallback={
+                <div className="flex min-h-screen items-center justify-center bg-background text-muted-foreground">
+                  Загрузка интерфейса...
+                </div>
+              }
+            >
+              <Router />
+            </Suspense>
+          </DropdownProvider>
         </TooltipProvider>
       </ThemeProvider>
     </QueryClientProvider>

--- a/client/src/components/checklist-selector.tsx
+++ b/client/src/components/checklist-selector.tsx
@@ -22,6 +22,7 @@ import {
   DialogTrigger,
 } from "@/components/ui/dialog";
 import { Checklist, InsertChecklist } from "@/lib/rest";
+import { useDropdownController } from "@/contexts/dropdown-provider";
 
 const ChecklistUpload = lazy(() =>
   import("@/components/checklist-upload").then((module) => ({
@@ -37,6 +38,7 @@ export function ChecklistSelector({ onChecklistChange }: ChecklistSelectorProps)
   const [activeId, setActiveId] = useState<string>("");
   const [uploadDialogOpen, setUploadDialogOpen] = useState(false);
   const { toast } = useToast();
+  const dropdown = useDropdownController("checklist-selector");
 
   // Fetch checklists from API
   const { data: checklists = [], isLoading } = useQuery<Checklist[]>({
@@ -93,6 +95,7 @@ export function ChecklistSelector({ onChecklistChange }: ChecklistSelectorProps)
     if (checklist) {
       onChecklistChange(checklist);
     }
+    dropdown.close();
   };
 
   const handleExport = () => {
@@ -180,11 +183,22 @@ export function ChecklistSelector({ onChecklistChange }: ChecklistSelectorProps)
           <CardTitle className="text-lg font-medium">Чек-лист</CardTitle>
         </CardHeader>
         <CardContent className="space-y-4">
-          <Select value={activeId} onValueChange={handleSelectChange} disabled={isLoading}>
+          <Select
+            value={activeId}
+            onValueChange={handleSelectChange}
+            disabled={isLoading}
+            open={dropdown.open}
+            onOpenChange={dropdown.onOpenChange}
+          >
             <SelectTrigger data-testid="select-checklist">
               <SelectValue placeholder={isLoading ? "Загрузка..." : "Выберите чек-лист"} />
             </SelectTrigger>
-            <SelectContent>
+            <SelectContent
+              position="popper"
+              sideOffset={6}
+              align="start"
+              className="z-50"
+            >
               {checklists.map((checklist) => (
                 <SelectItem key={checklist.id} value={checklist.id}>
                   {checklist.name}

--- a/client/src/components/manager-selector.tsx
+++ b/client/src/components/manager-selector.tsx
@@ -10,6 +10,7 @@ import {
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Manager } from "@/lib/rest";
+import { useDropdownController } from "@/contexts/dropdown-provider";
 
 interface ManagerSelectorProps {
   onManagerChange: (managerId: string | null) => void;
@@ -18,6 +19,7 @@ interface ManagerSelectorProps {
 
 export function ManagerSelector({ onManagerChange, selectedManagerId }: ManagerSelectorProps) {
   const [activeId, setActiveId] = useState<string | null>(selectedManagerId || null);
+  const dropdown = useDropdownController("manager-selector");
 
   const { data: managers = [], isLoading } = useQuery<Manager[]>({
     queryKey: ["/api/managers"],
@@ -33,6 +35,7 @@ export function ManagerSelector({ onManagerChange, selectedManagerId }: ManagerS
     const managerId = value === "none" ? null : value;
     setActiveId(managerId);
     onManagerChange(managerId);
+    dropdown.close();
   };
 
   const activeManager = managers.find((m) => m.id === activeId);
@@ -56,11 +59,21 @@ export function ManagerSelector({ onManagerChange, selectedManagerId }: ManagerS
         <CardTitle>Выбор менеджера</CardTitle>
       </CardHeader>
       <CardContent className="space-y-4">
-        <Select value={activeId || "none"} onValueChange={handleSelectChange}>
+        <Select
+          value={activeId || "none"}
+          onValueChange={handleSelectChange}
+          open={dropdown.open}
+          onOpenChange={dropdown.onOpenChange}
+        >
           <SelectTrigger data-testid="select-manager">
             <SelectValue placeholder="Выберите менеджера" />
           </SelectTrigger>
-          <SelectContent>
+          <SelectContent
+            position="popper"
+            sideOffset={6}
+            align="start"
+            className="z-50"
+          >
             <SelectItem value="none" data-testid="select-manager-none">
               Не указан
             </SelectItem>

--- a/client/src/contexts/dropdown-provider.tsx
+++ b/client/src/contexts/dropdown-provider.tsx
@@ -1,0 +1,54 @@
+import { createContext, useCallback, useContext, useMemo, useState } from "react";
+import type { ReactNode } from "react";
+
+interface DropdownContextValue {
+  openId: string | null;
+  setOpenId: (id: string | null) => void;
+}
+
+const DropdownContext = createContext<DropdownContextValue | undefined>(undefined);
+
+export function DropdownProvider({ children }: { children: ReactNode }) {
+  const [openId, setOpenIdState] = useState<string | null>(null);
+
+  const setOpenId = useCallback((id: string | null) => {
+    setOpenIdState(id);
+  }, []);
+
+  const value = useMemo(
+    () => ({
+      openId,
+      setOpenId,
+    }),
+    [openId, setOpenId]
+  );
+
+  return <DropdownContext.Provider value={value}>{children}</DropdownContext.Provider>;
+}
+
+export function useDropdownController(id: string) {
+  const context = useContext(DropdownContext);
+
+  if (!context) {
+    throw new Error("useDropdownController must be used within a DropdownProvider");
+  }
+
+  const { openId, setOpenId } = context;
+
+  const handleOpenChange = useCallback(
+    (open: boolean) => {
+      setOpenId(open ? id : null);
+    },
+    [id, setOpenId]
+  );
+
+  const close = useCallback(() => {
+    setOpenId(null);
+  }, [setOpenId]);
+
+  return {
+    open: openId === id,
+    onOpenChange: handleOpenChange,
+    close,
+  };
+}


### PR DESCRIPTION
## Summary
- add a dropdown context provider so only one selector menu can be open at a time
- update manager and checklist selectors to render their menus in portals with popper positioning and high z-index styling
- wrap the app with the dropdown provider to share open state between selectors

## Testing
- npm run build --prefix client *(fails: vite not found in container environment)*

------
https://chatgpt.com/codex/tasks/task_e_690850b891948325a501002b4f69978b