### PR TITLE
Open select dropdowns upward

### DIFF
--- a/client/src/components/checklist-selector.tsx
+++ b/client/src/components/checklist-selector.tsx
@@ -195,6 +195,7 @@ export function ChecklistSelector({ onChecklistChange }: ChecklistSelectorProps)
             </SelectTrigger>
             <SelectContent
               position="popper"
+              side="top"
               sideOffset={6}
               align="start"
               className="z-50"

--- a/client/src/components/manager-selector.tsx
+++ b/client/src/components/manager-selector.tsx
@@ -70,6 +70,7 @@ export function ManagerSelector({ onManagerChange, selectedManagerId }: ManagerS
           </SelectTrigger>
           <SelectContent
             position="popper"
+            side="top"
             sideOffset={6}
             align="start"
             className="z-50"


### PR DESCRIPTION
## Summary
- update the checklist selector dropdown to open upward so it no longer covers the actions below it
- apply the same upward opening behavior to the manager selector dropdown for consistency

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_690852d9635c832594d81a6b6adce676